### PR TITLE
fix: correct V(A) advancement — prevent state corruption on N(R)=0

### DIFF
--- a/aioax25/peer.py
+++ b/aioax25/peer.py
@@ -592,7 +592,10 @@ class AX25Peer(object):
         # proceed to the retransmission procedure in 2.4.4.9."
 
         # Check N(R) for received frames.
-        self._ack_outstanding((frame.nr - 1) % self._modulo)
+        # N(R) means "I have received all frames up to N(R)-1".
+        # Pass N(R) directly — _ack_outstanding loops V(A) until it
+        # reaches nr, acknowledging each frame along the way.
+        self._ack_outstanding(frame.nr)
 
     def _on_receive_iframe(self, frame):
         """
@@ -735,8 +738,20 @@ class AX25Peer(object):
 
     def _ack_outstanding(self, nr):
         """
-        Receive all frames up to N(R)-1
+        Acknowledge all frames up to (but not including) N(R).
         """
+        dist = (nr - self._ack_state) % self._modulo
+        if dist == 0:
+            return
+        if dist > self._max_outstanding:
+            self._log.debug(
+                "Skipping bogus ACK: V(A)=%d nr=%d dist=%d",
+                self._ack_state,
+                nr,
+                dist,
+            )
+            return
+
         self._log.debug("%d through to %d are received", self._ack_state, nr)
         while self._ack_state != nr:
             if self._log.isEnabledFor(logging.DEBUG):  # pragma: no cover


### PR DESCRIPTION
Fixes #24.

### What

Corrects the N(R) acknowledgement formula in `_on_receive_isframe_nr_ns()` and adds a distance guard in `_ack_outstanding()`.

### Why

Line 595 calls `self._ack_outstanding((frame.nr - 1) % self._modulo)`, which has two bugs:

1. **N(R)=1** → `_ack_outstanding(0)` → distance is 0 → no-op. The first I-frame is never acknowledged.
2. **N(R)=0** (common right after connection setup) → `_ack_outstanding(7)` → V(A) wraps from 0 through 7, destroying all sequence state. Subsequent I-frames are silently ignored.

Per the AX.25 2.2 specification, N(R) means "I have received all frames with sequence numbers up to N(R)-1". The correct call is `_ack_outstanding(frame.nr)` — this loops V(A) from its current value until it reaches N(R), acknowledging each frame along the way.

### How

1. Changed line 595 to `self._ack_outstanding(frame.nr)`
2. Added a distance guard at the top of `_ack_outstanding()`: if the distance from V(A) to N(R) exceeds `max_outstanding`, the ACK is treated as bogus and skipped

### Testing

- Verified against DB0HOF (XNET) and DB0ED (XNET/OE5DXL) on HAMNET
- [Web4PR](https://github.com/DK5EN/web4pr) test harness (728 tests) exercises the full sequence number lifecycle

---
Martin (DK5EN) — www.qrz.com/db/DK5EN