### PR TITLE
fix: sync _recv_seq after each I-frame receive to prevent stale N(R)

### DIFF
--- a/aioax25/peer.py
+++ b/aioax25/peer.py
@@ -631,6 +631,17 @@ class AX25Peer(object):
         )
         self._on_receive_isframe_nr_ns(frame)
 
+        # Keep _recv_seq in sync with _recv_state so the next I-frame's
+        # sequence check (frame.ns != self._recv_seq) uses the current
+        # value.  Without this, burst receives leave _recv_seq stale and
+        # frames 2+ are silently dropped.
+        if self._recv_state != self._recv_seq:
+            self._update_state(
+                "_recv_seq",
+                value=self._recv_state,
+                comment="sync after RX",
+            )
+
         # TODO: the payload here may be a repeat of data already seen, or
         # for _future_ data (i.e. there's an I-frame that got missed in between
         # the last one we saw, and this one).  How do we handle this possibly


### PR DESCRIPTION
Fixes #25.

### What

Keeps `_recv_seq` in sync with `_recv_state` after each accepted I-frame, preventing stale N(R) values during burst receives.

### Why

`_recv_seq` (the value used in the sequence check `if frame.ns != self._recv_seq` at line 617) is only synchronised from `_recv_state` (V(R)) before *sending*. When the peer sends multiple I-frames in rapid succession — common during welcome banners, directory listings, or BBS output — `_recv_seq` stays at its initial value. Frames 2 onwards are silently dropped:

> I-frame sequence N(S) is X, expecting N(R) Y, ignoring

The data *is* delivered to the application layer (the welcome text displays correctly), but the protocol-level acknowledgement N(R) never advances. The remote node enters a perpetual RR poll loop.

### Evidence

Captured from a real session with DB0ED (XNET/OE5DXL on HAMNET):

```
1. Connect successful (SABM→UA)
2. DB0ED sends welcome — we receive 1.8 KB across multiple I-frames
3. We send H\r, receive help OK; send I\r, receive info OK
4. We send Links\r — no response
5. DB0ED polls: RR(4) F → we respond RR(1) → infinite loop at ~700ms
```

### How

After `_on_receive_isframe_nr_ns(frame)` in `_on_receive_iframe()`, sync `_recv_seq` from `_recv_state` if they differ.

### Testing

- Verified against DB0ED, DB0HOF, DB0FHN on HAMNET
- [Web4PR](https://github.com/DK5EN/web4pr) test harness (728 tests) with mock peers exercising burst I-frame scenarios

---
Martin (DK5EN) — www.qrz.com/db/DK5EN