### PR TITLE
fix: retransmit pending I-frames after RNR→RR recovery

### DIFF
--- a/aioax25/peer.py
+++ b/aioax25/peer.py
@@ -680,8 +680,32 @@ class AX25Peer(object):
             self._log.debug(
                 "RR notification received from peer N(R)=%d", frame.nr
             )
+            was_busy = self._peer_busy
             self._peer_busy = False
             self._send_next_iframe()
+
+            # After RNR→RR transition: retransmit pending frames.
+            # The window may be full with already-transmitted frames that
+            # the busy peer never received.  Reset V(S) to frame.nr and
+            # retransmit — same logic as the REJ handler (sect 6.4.7).
+            if (
+                was_busy
+                and self._pending_iframes
+                and frame.nr != self._send_state
+            ):
+                self._log.info(
+                    "RNR recovery: retransmitting from N(R)=%d "
+                    "(V(S)=%d, %d pending)",
+                    frame.nr,
+                    self._send_state,
+                    len(self._pending_iframes),
+                )
+                self._update_state(
+                    "_send_state",
+                    value=frame.nr,
+                    comment="RNR recovery retransmit",
+                )
+                self._send_next_iframe()
 
     def _on_receive_rnr(self, frame):
         if frame.pf:


### PR DESCRIPTION
Fixes #28.

### What

After an RNR→RR transition, reset V(S) to `frame.nr` and retransmit pending I-frames that the busy peer never received.

### Why

When a peer sends RNR followed by RR, `_on_receive_rr()` clears `_peer_busy` and calls `_send_next_iframe()`. However, the transmit window is full with already-transmitted frames — `_send_next_iframe()` sees `len(self._pending_iframes) >= max_outstanding` and returns immediately. No retransmission occurs, and the session stalls permanently.

The existing REJ handler at line 696-710 handles this correctly by resetting V(S) to `frame.nr` before calling `_send_next_iframe()`. The RR handler after RNR recovery should follow the same pattern.

### Evidence

Real-world scenario captured during a file upload through DB0HOF (XNET) on HAMNET:

```
19:51:59  We send I(0)..I(7) — window full, 8 frames pending
19:51:59  Remote sends RNR(4) ×4 — busy, received up to 3
19:52:00  Remote sends RR(4) — ready, still at frame 4
          _send_next_iframe → window full → returns immediately
          *** SESSION STUCK — no retransmission ***
```

### How

Track `was_busy` before clearing `_peer_busy`. After the transition, if `frame.nr != self._send_state` (peer has not received all our frames), reset V(S) and call `_send_next_iframe()` to begin retransmission.

### Testing

- 6 unit tests in [Web4PR](https://github.com/DK5EN/web4pr) covering: basic recovery, N(R)==V(S) guard, normal RR (no RNR), P/F path, empty pending, modulo-8 wraparound
- Verified against DB0HOF relay on HAMNET during file uploads

---
Martin (DK5EN) — www.qrz.com/db/DK5EN