### PR TITLE
fix: guard frame-sending methods against dead station weakref

### DIFF
--- a/aioax25/peer.py
+++ b/aioax25/peer.py
@@ -1287,6 +1287,8 @@ class AX25Peer(object):
         """
         Send a SABM(E) frame to the remote station.
         """
+        if self._station() is None:
+            return
         self._log.info("Sending SABM%s", "E" if self._modulo128 else "")
         SABMClass = (
             AX25SetAsyncBalancedModeExtendedFrame
@@ -1305,6 +1307,8 @@ class AX25Peer(object):
             self._set_conn_state(AX25PeerState.CONNECTING)
 
     def _send_xid(self, cr):
+        if self._station() is None:
+            return
         self._transmit_frame(
             AX25ExchangeIdentificationFrame(
                 destination=self.address.normcopy(ch=True),
@@ -1362,6 +1366,8 @@ class AX25Peer(object):
         """
         Send a DM frame to the remote station.
         """
+        if self._station() is None:
+            return
         self._log.info("Sending DM")
         self._transmit_frame(
             AX25DisconnectModeFrame(
@@ -1375,6 +1381,8 @@ class AX25Peer(object):
         """
         Send a DISC frame to the remote station.
         """
+        if self._station() is None:
+            return
         self._log.info("Sending DISC")
         self._transmit_frame(
             AX25DisconnectFrame(
@@ -1388,6 +1396,8 @@ class AX25Peer(object):
         """
         Send a UA frame to the remote station.
         """
+        if self._station() is None:
+            return
         self._log.info("Sending UA")
         self._transmit_frame(
             AX25UnnumberedAcknowledgeFrame(
@@ -1401,6 +1411,8 @@ class AX25Peer(object):
         """
         Send a FRMR frame to the remote station.
         """
+        if self._station() is None:
+            return
         self._log.debug("Sending FRMR in reply to %s", frame)
 
         # AX.25 2.0 sect 2.4.5: "After sending the FRMR frame, the sending DXE
@@ -1450,6 +1462,9 @@ class AX25Peer(object):
         """
         Send a RR notification frame
         """
+        if self._station() is None:
+            return
+
         # "If there are no outstanding I frames, the receiving device will
         # send a RR frame with N(R) equal to V(R). The receiving DXE may wait
         # a small period of time before sending the RR frame to be sure
@@ -1475,6 +1490,8 @@ class AX25Peer(object):
         """
         Send a RNR notification if the RNR interval has elapsed.
         """
+        if self._station() is None:
+            return
         if self._state is AX25PeerState.CONNECTED:
             now = self._loop.time()
             if (now - self._last_rnr_sent) > self._rnr_interval:
@@ -1529,6 +1546,8 @@ class AX25Peer(object):
         """
         Transmit the I-frame identified by the given N(S) parameter.
         """
+        if self._station() is None:
+            return
         # "Whenever a DXE has an I frame to transmit, it will send the I frame
         # with N(S) of the control field equal to its current send state
         # variable V(S). Once the I frame is sent, the send state variable is
@@ -1564,6 +1583,8 @@ class AX25Peer(object):
         )
 
     def _transmit_frame(self, frame, callback=None):
+        if self._station() is None:
+            return
         self.sent_frame.emit(frame=frame, peer=self)
 
         # Update the last activity timestamp


### PR DESCRIPTION
Fixes #29.

### What

Adds a null-check for `self._station()` at the top of all frame-sending methods, preventing `AttributeError` crashes when the station has been garbage-collected.

### Why

After a connected-mode session is disconnected and cleaned up, the station object may be garbage-collected, causing the peer's weakref (`self._station()`) to return `None`. However, pending asyncio timer callbacks — connection retry timeouts, RR notification delays, idle cleanup — still fire and call methods that dereference `self._station().address`:

```
File "aioax25/peer.py", line 1760, in _on_timeout
    self._on_negotiated(response="retry")
  File "aioax25/peer.py", line 1731, in _on_negotiated
    self.peer._send_sabm()
  File "aioax25/peer.py", line 1300, in _send_sabm
    source=self._station().address.normcopy(ch=False),
           ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'address'
```

In production (Raspberry Pi running [Web4PR](https://github.com/DK5EN/web4pr) with multiple users), this fires **15+ times per session** during the cleanup phase. The exceptions are caught by the asyncio event loop and do not crash the process, but they spam logs and indicate zombie peers.

### How

Added `if self._station() is None: return` at the top of:
- `_send_sabm`, `_send_xid`, `_send_dm`, `_send_disc`, `_send_ua`, `_send_frmr`
- `_send_rr_notification`, `_send_rnr_notification`
- `_transmit_iframe`, `_transmit_frame`

When the station is gone, there is no interface to transmit on. Skipping the send is safe and cannot leave protocol state inconsistent.

### Testing

- Verified in production on rpizero.local with multiple users connecting/disconnecting
- [Web4PR](https://github.com/DK5EN/web4pr) test harness (728 tests)

---
Martin (DK5EN) — www.qrz.com/db/DK5EN