### PR TITLE
fix: send REJ on out-of-sequence I-frame with exception handling

### DIFF
--- a/aioax25/peer.py
+++ b/aioax25/peer.py
@@ -615,13 +615,56 @@ class AX25Peer(object):
         # send sequence number equals the receiver's receive state variable) and
         # is not in the busy condition,…"
         if frame.ns != self._recv_seq:
-            # TODO: should we send a REJ/SREJ after a time-out?
-            self._log.debug(
-                "I-frame sequence N(S) is %s, expecting N(R) %s, ignoring",
-                frame.ns,
-                self._recv_seq,
-            )
+            # Distinguish forward gap from duplicate/old retransmission
+            # using modulo distance.
+            dist = (frame.ns - self._recv_seq) % self._modulo
+            if 0 < dist < self._modulo // 2:
+                # Forward gap — lost frame(s).  AX.25 2.2 sect 6.4.2.3:
+                # send REJ(N(R)=V(R)) to request retransmission.
+                # Sect 6.4.4 (REJ exception): only one REJ per gap.
+                if not getattr(self, "_rej_exception", False):
+                    self._log.warning(
+                        "Forward gap: I-frame N(S)=%d, expected N(R)=%d "
+                        "— sending REJ",
+                        frame.ns,
+                        self._recv_seq,
+                    )
+                    self._rej_exception = True
+                    station = self._station()
+                    if self._REJFrameClass is not None and station is not None:
+                        self._cancel_rr_notification()
+                        self._transmit_frame(
+                            self._REJFrameClass(
+                                destination=self.address.normcopy(ch=True),
+                                source=station.address.normcopy(ch=False),
+                                repeaters=self.reply_path,
+                                pf=False,
+                                nr=self._recv_state,
+                            )
+                        )
+                else:
+                    self._log.debug(
+                        "REJ exception: suppressing REJ for N(S)=%d "
+                        "(waiting for N(R)=%d)",
+                        frame.ns,
+                        self._recv_seq,
+                    )
+            else:
+                # Duplicate/old retransmission — silently ignore.
+                self._log.debug(
+                    "Duplicate I-frame N(S)=%d, V(R)=%d — ignoring",
+                    frame.ns,
+                    self._recv_seq,
+                )
             return
+
+        # In-sequence frame — clear REJ exception condition.
+        if getattr(self, "_rej_exception", False):
+            self._log.info(
+                "REJ exception cleared: received expected N(S)=%d",
+                frame.ns,
+            )
+            self._rej_exception = False
 
         # "…it accepts the received I frame,
         # increments its receive state variable, and acts in one of the

--- a/aioax25/peer.py
+++ b/aioax25/peer.py
@@ -631,6 +631,17 @@ class AX25Peer(object):
         )
         self._on_receive_isframe_nr_ns(frame)
 
+        # Keep _recv_seq in sync with _recv_state so the next I-frame's
+        # sequence check (frame.ns != self._recv_seq) uses the current
+        # value.  Without this, burst receives leave _recv_seq stale and
+        # frames 2+ are silently dropped.
+        if self._recv_state != self._recv_seq:
+            self._update_state(
+                "_recv_seq",
+                value=self._recv_state,
+                comment="sync after RX",
+            )
+
         # TODO: the payload here may be a repeat of data already seen, or
         # for _future_ data (i.e. there's an I-frame that got missed in between
         # the last one we saw, and this one).  How do we handle this possibly


### PR DESCRIPTION
Fixes #26.

> **Note:** This PR includes the `_recv_seq` sync fix from #32 as a prerequisite, since REJ handling depends on `_recv_seq` being correct.

### What

Sends REJ frames on sequence gaps per AX.25 2.2, with proper REJ exception handling (section 6.4.4).

### Why

When I-frames arrive with a sequence gap (common with AXUDP over HAMNET where UDP packets can be lost), `_on_receive_iframe()` silently drops the out-of-sequence frame (line 617-624). The existing TODO at line 618 acknowledges this:

```python
# TODO: should we send a REJ/SREJ after a time-out?
```

Per AX.25 2.2 section 6.4.2.3, the correct response is to send REJ(N(R)=V(R)) immediately, requesting retransmission from the missing frame. Without this, the session hangs in an RR poll loop.

### How

1. **Forward gap detection**: Uses modulo distance to distinguish lost frames from duplicate/old retransmissions
2. **REJ transmission**: Sends REJ(N(R)=V(R)) on forward gaps
3. **REJ exception** (section 6.4.4): Only one REJ per gap — sets `_rej_exception` flag, suppresses further REJ until expected frame arrives
4. **Exception clearing**: When the in-sequence frame arrives, clears `_rej_exception`

### Testing

- 5 integration tests in [Web4PR](https://github.com/DK5EN/web4pr): sequence gap, burst gap, duplicate frame, REJ storm suppression, connectivity
- Mock peers with `SequenceGapBehavior`, `BurstGapBehavior`, `DuplicateFrameBehavior`
- Verified against DB0ED (XNET/OE5DXL) and DB0FFL-8 (OpenBCM) on HAMNET

---
Martin (DK5EN) — www.qrz.com/db/DK5EN