### PR TITLE
fix: break RR poll loop when in REJ exception

### DIFF
--- a/aioax25/peer.py
+++ b/aioax25/peer.py
@@ -615,13 +615,56 @@ class AX25Peer(object):
         # send sequence number equals the receiver's receive state variable) and
         # is not in the busy condition,…"
         if frame.ns != self._recv_seq:
-            # TODO: should we send a REJ/SREJ after a time-out?
-            self._log.debug(
-                "I-frame sequence N(S) is %s, expecting N(R) %s, ignoring",
-                frame.ns,
-                self._recv_seq,
-            )
+            # Distinguish forward gap from duplicate/old retransmission
+            # using modulo distance.
+            dist = (frame.ns - self._recv_seq) % self._modulo
+            if 0 < dist < self._modulo // 2:
+                # Forward gap — lost frame(s).  AX.25 2.2 sect 6.4.2.3:
+                # send REJ(N(R)=V(R)) to request retransmission.
+                # Sect 6.4.4 (REJ exception): only one REJ per gap.
+                if not getattr(self, "_rej_exception", False):
+                    self._log.warning(
+                        "Forward gap: I-frame N(S)=%d, expected N(R)=%d "
+                        "— sending REJ",
+                        frame.ns,
+                        self._recv_seq,
+                    )
+                    self._rej_exception = True
+                    station = self._station()
+                    if self._REJFrameClass is not None and station is not None:
+                        self._cancel_rr_notification()
+                        self._transmit_frame(
+                            self._REJFrameClass(
+                                destination=self.address.normcopy(ch=True),
+                                source=station.address.normcopy(ch=False),
+                                repeaters=self.reply_path,
+                                pf=False,
+                                nr=self._recv_state,
+                            )
+                        )
+                else:
+                    self._log.debug(
+                        "REJ exception: suppressing REJ for N(S)=%d "
+                        "(waiting for N(R)=%d)",
+                        frame.ns,
+                        self._recv_seq,
+                    )
+            else:
+                # Duplicate/old retransmission — silently ignore.
+                self._log.debug(
+                    "Duplicate I-frame N(S)=%d, V(R)=%d — ignoring",
+                    frame.ns,
+                    self._recv_seq,
+                )
             return
+
+        # In-sequence frame — clear REJ exception condition.
+        if getattr(self, "_rej_exception", False):
+            self._log.info(
+                "REJ exception cleared: received expected N(S)=%d",
+                frame.ns,
+            )
+            self._rej_exception = False
 
         # "…it accepts the received I frame,
         # increments its receive state variable, and acts in one of the

--- a/aioax25/peer.py
+++ b/aioax25/peer.py
@@ -631,6 +631,17 @@ class AX25Peer(object):
         )
         self._on_receive_isframe_nr_ns(frame)
 
+        # Keep _recv_seq in sync with _recv_state so the next I-frame's
+        # sequence check (frame.ns != self._recv_seq) uses the current
+        # value.  Without this, burst receives leave _recv_seq stale and
+        # frames 2+ are silently dropped.
+        if self._recv_state != self._recv_seq:
+            self._update_state(
+                "_recv_seq",
+                value=self._recv_state,
+                comment="sync after RX",
+            )
+
         # TODO: the payload here may be a repeat of data already seen, or
         # for _future_ data (i.e. there's an I-frame that got missed in between
         # the last one we saw, and this one).  How do we handle this possibly

--- a/aioax25/peer.py
+++ b/aioax25/peer.py
@@ -783,9 +783,46 @@ class AX25Peer(object):
         if self._local_busy:
             self._log.debug("RR poll request from peer: we're busy")
             self._send_rnr_notification()
+            return
+
+        # Track consecutive polls with the same stale V(R).  If in REJ
+        # exception or after 3+ stale polls, respond with REJ instead of
+        # RR to re-request the missing frame and break the loop.
+        poll_count = getattr(self, "_stale_poll_count", 0) + 1
+        last_poll_vr = getattr(self, "_last_poll_vr", None)
+
+        if last_poll_vr == self._recv_state:
+            self._stale_poll_count = poll_count
         else:
-            self._log.debug("RR poll request from peer: we're ready")
-            self._send_rr_notification()
+            self._stale_poll_count = 1
+            self._last_poll_vr = self._recv_state
+
+        in_rej = getattr(self, "_rej_exception", False)
+        if in_rej or poll_count >= 3:
+            station = self._station()
+            if self._REJFrameClass is not None and station is not None:
+                self._log.warning(
+                    "Poll loop detected (count=%d, rej_exception=%s): "
+                    "sending REJ(N(R)=%d) instead of RR",
+                    poll_count,
+                    in_rej,
+                    self._recv_state,
+                )
+                self._rej_exception = True
+                self._cancel_rr_notification()
+                self._transmit_frame(
+                    self._REJFrameClass(
+                        destination=self.address.normcopy(ch=True),
+                        source=station.address.normcopy(ch=False),
+                        repeaters=self.reply_path,
+                        pf=False,
+                        nr=self._recv_state,
+                    )
+                )
+                return
+
+        self._log.debug("RR poll request from peer: we're ready")
+        self._send_rr_notification()
 
     def _ack_outstanding(self, nr):
         """


### PR DESCRIPTION
Fixes #27.

> **Note:** This PR depends on the REJ exception mechanism from #35 (`_rej_exception` attribute).

### What

When responding to RR polls during a REJ exception (or after detecting 3+ stale polls), responds with REJ instead of RR to re-request the missing frame and break the infinite poll loop.

### Why

When in REJ exception state (waiting for a retransmitted frame after a sequence gap), `_on_receive_rr_rnr_rej_query()` responds with a plain RR containing the current (stale) V(R). The remote node sees we have not advanced and polls again. This creates an infinite RR poll loop at ~700ms intervals that never resolves.

### How

1. Track consecutive polls with the same stale V(R)
2. If in REJ exception **or** poll count reaches 3: send REJ(N(R)=V(R)) instead of RR
3. This re-requests the missing frame, giving the remote node a clear signal of what we need

### Evidence

DB0ED sessions entering infinite 700ms RR poll loops. Captured in production — the remote node polls with RR(4) F, we respond with RR(1), indefinitely.

### Testing

- Verified against DB0ED (XNET/OE5DXL) on HAMNET
- [Web4PR](https://github.com/DK5EN/web4pr) test harness (728 tests)

---
Martin (DK5EN) — www.qrz.com/db/DK5EN